### PR TITLE
Change Dependabot commit message prefix to 'chore'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
 
     # Ensure Conventional Commits for Dependabot update commits
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
       include: "scope"
 
     # Helpful labels for policies/filters


### PR DESCRIPTION
This pull request makes a small adjustment to the Dependabot configuration by changing the commit message prefix for dependency updates to "chore" instead of "chore(deps)".